### PR TITLE
Example build script doesn't work on custom node installs

### DIFF
--- a/example/build.js
+++ b/example/build.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 require.paths.push(__dirname);
 require.paths.push(__dirname + '/../lib');


### PR DESCRIPTION
switched to a more universal hash-bang.
